### PR TITLE
Allow doctrine/persistence 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   "require": {
     "php": "^7.4 || ^8.0",
     "doctrine/orm": "^2.9",
-    "doctrine/persistence": "^2.2",
+    "doctrine/persistence": "^2.2 || ^3.0",
     "jawira/db-draw": "^1.2",
     "jawira/plantuml-client": "^1.0",
     "symfony/console": "^5.0 || ^6.0",


### PR DESCRIPTION
Only 1 file using \Doctrine\Persistence\ConnectionRegistry, and the interface is not BC in v3, so it is well to allow v3.