### PR TITLE
fix: Add proper return value to Configuration

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -11,7 +11,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-  public function getConfigTreeBuilder()
+  public function getConfigTreeBuilder(): TreeBuilder
   {
     $buildTree = (new TreeBuilder('doctrine_diagram'));
     /** @var ParentNodeDefinitionInterface $rootNode */


### PR DESCRIPTION
Add proper return value to Configuration to fix Symfony deprecation complaints.

Closes #14 