### PR TITLE
(Possible) upgrade to Symfony 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     "doctrine/persistence": "^2.2 || ^3.0",
     "jawira/db-draw": "^1.2",
     "jawira/plantuml-client": "^1.0",
-    "symfony/console": "^5.0 || ^6.0",
-    "symfony/filesystem": "^5.0 || ^6.0",
-    "symfony/framework-bundle": "^5.0 || ^6.0"
+    "symfony/console": "^5.0 || ^6.0 || ^7.0",
+    "symfony/filesystem": "^5.0 || ^6.0 || ^7.0",
+    "symfony/framework-bundle": "^5.0 || ^6.0 || ^7.0"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.15",


### PR DESCRIPTION
I've added the possibility to use Symfony 7.0 as well. Tried running it both with a 6.4- as well as a 7.0-project worked fine.