### PR TITLE
fix: Update dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     "doctrine/orm": "^2.9 || ^3.0",
     "jawira/db-draw": "^1.2",
     "jawira/plantuml-client": "^1.0",
-    "symfony/console": "^5.4 || ^6.0 || ^7.0",
-    "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
-    "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0"
+    "symfony/console": "^6.0 || ^7.0",
+    "symfony/filesystem": "^6.0 || ^7.0",
+    "symfony/framework-bundle": "^6.0 || ^7.0"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.31",


### PR DESCRIPTION
Remove dependencies to Symfony v5.4 to comply with symfony/recipes-contrib