### PR TITLE
refactor: Create "doctrine:diagram:er" command

### DIFF
--- a/src/Command/ErDiagramCommand.php
+++ b/src/Command/ErDiagramCommand.php
@@ -5,7 +5,8 @@ namespace Jawira\DoctrineDiagramBundle\Command;
 use Jawira\DoctrineDiagramBundle\Constants\Config;
 use Jawira\DoctrineDiagramBundle\Constants\Info;
 use Jawira\DoctrineDiagramBundle\Constants\Size;
-use Jawira\DoctrineDiagramBundle\Service\DoctrineDiagram;
+use Jawira\DoctrineDiagramBundle\Service\ConversionService;
+use Jawira\DoctrineDiagramBundle\Service\ErDiagram;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -17,11 +18,13 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * @author  Jawira Portugal
  */
-#[AsCommand('doctrine:diagram', 'Create a database diagram.')]
-class DoctrineDiagramCommand extends Command
+#[AsCommand('doctrine:diagram:er', 'Create an Entity-Relationship diagram.')]
+class ErDiagramCommand extends Command
 {
-  public function __construct(private DoctrineDiagram $doctrineDiagram)
-  {
+  public function __construct(
+    private ErDiagram         $erDiagram,
+    private ConversionService $conversionService,
+  ) {
     parent::__construct();
   }
 
@@ -70,9 +73,9 @@ class DoctrineDiagramCommand extends Command
 
     $excludeArray = is_string($exclude) ? explode(',', $exclude) : null;
 
-    $puml     = $this->doctrineDiagram->generatePuml($connectionName, $size, $theme, $excludeArray);
-    $content  = $this->doctrineDiagram->convert($puml, $format, $converter, $server, $jar);
-    $fullName = $this->doctrineDiagram->dumpDiagram($content, $filename, $format);
+    $puml     = $this->erDiagram->generatePuml($connectionName, $size, $theme, $excludeArray);
+    $content  = $this->conversionService->convert($puml, $format, $converter, $server, $jar);
+    $fullName = $this->conversionService->dumpDiagram($content, $filename, $format);
 
     $errorStyle->success("Diagram: $fullName");
 

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -2,9 +2,10 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Jawira\DoctrineDiagramBundle\Command\DoctrineDiagramCommand;
+use Jawira\DoctrineDiagramBundle\Command\ErDiagramCommand;
 use Jawira\DoctrineDiagramBundle\Constants\Config as C;
-use Jawira\DoctrineDiagramBundle\Service\DoctrineDiagram;
+use Jawira\DoctrineDiagramBundle\Service\ConversionService;
+use Jawira\DoctrineDiagramBundle\Service\ErDiagram;
 use Jawira\DoctrineDiagramBundle\Service\Toolbox;
 use Jawira\PlantUmlToImage\PlantUml;
 
@@ -15,24 +16,30 @@ return function (ContainerConfigurator $container): void {
   $services->set('.jawira.doctrine_diagram.toolbox', Toolbox::class);
 
   $c = Toolbox::concat(...);
-  $services->set('jawira.doctrine_diagram.service', DoctrineDiagram::class)
+  $services->set('jawira.doctrine_diagram.er_diagram', ErDiagram::class)
+    // services
     ->arg('$doctrine', service('doctrine'))
-    ->arg('$pumlToImage', service('.jawira.doctrine_diagram.plantuml_to_image'))
-    ->arg('$toolbox', service('.jawira.doctrine_diagram.toolbox'))
-    // er
-    ->arg('$filename', param($c(C::ROOT, C::ER, C::FILENAME)))
+    // parameters
     ->arg('$size', param($c(C::ROOT, C::ER, C::SIZE)))
-    ->arg('$format', param($c(C::ROOT, C::ER, C::FORMAT)))
     ->arg('$theme', param($c(C::ROOT, C::ER, C::THEME)))
     ->arg('$connection', param($c(C::ROOT, C::ER, C::CONNECTION)))
-    ->arg('$exclude', param($c(C::ROOT, C::ER, C::EXCLUDE)))
-    // convert
+    ->arg('$exclude', param($c(C::ROOT, C::ER, C::EXCLUDE)));
+
+  $services->set('jawira.doctrine_diagram.conversion_service', ConversionService::class)
+    // services
+    ->arg('$pumlToImage', service('.jawira.doctrine_diagram.plantuml_to_image'))
+    ->arg('$toolbox', service('.jawira.doctrine_diagram.toolbox'))
+    // parameters
+    ->arg('$filename', param($c(C::ROOT, C::ER, C::FILENAME)))
+    ->arg('$format', param($c(C::ROOT, C::ER, C::FORMAT)))
     ->arg('$converter', param($c(C::ROOT, C::CONVERT, C::CONVERTER)))
     ->arg('$jar', param($c(C::ROOT, C::CONVERT, C::JAR)))
     ->arg('$server', param($c(C::ROOT, C::CONVERT, C::SERVER)));
 
-  $services->set('jawira.doctrine_diagram.command', DoctrineDiagramCommand::class)
-    ->arg('$doctrineDiagram', service('jawira.doctrine_diagram.service'))
+
+  $services->set('jawira.doctrine_diagram.command', ErDiagramCommand::class)
+    ->arg('$erDiagram', service('jawira.doctrine_diagram.er_diagram'))
+    ->arg('$conversionService', service('jawira.doctrine_diagram.conversion_service'))
     ->tag('console.command')
     ->private();
 };

--- a/src/Service/ConversionService.php
+++ b/src/Service/ConversionService.php
@@ -2,62 +2,23 @@
 
 namespace Jawira\DoctrineDiagramBundle\Service;
 
-use Doctrine\DBAL\Connection;
-use Doctrine\Persistence\ConnectionRegistry;
-use Jawira\DbDraw\DbDraw;
 use Jawira\DoctrineDiagramBundle\Constants\Converter;
 use Jawira\DoctrineDiagramBundle\Constants\Format;
 use Jawira\PlantUmlClient\Client;
 use Jawira\PlantUmlToImage\PlantUml;
-use RuntimeException;
-use Symfony\Component\Filesystem\Filesystem;
-use function file_put_contents;
-use function is_string;
 
-/**
- * Main service to generate diagrams.
- */
-class DoctrineDiagram
+class ConversionService
 {
   public function __construct(
-    private ConnectionRegistry $doctrine,
-    private PlantUml           $pumlToImage,
-    private Toolbox            $toolbox,
-    private string             $size,
-    private string             $filename,
-    private string             $format,
-    private ?string            $jar,
-    private string             $server,
-    private string             $converter,
-    private string             $theme,
-    private ?string            $connection,
-    /** @var string[] */
-    private array              $exclude,
+
+    private PlantUml $pumlToImage,
+    private Toolbox  $toolbox,
+    private string   $filename,
+    private string   $format,
+    private ?string  $jar,
+    private string   $server,
+    private string   $converter,
   ) {
-  }
-
-  /**
-   * Generate a Puml diagram using a Doctrine connection.
-   *
-   * The arguments of this method come from the console. If no values are provided, then the values from the config
-   * file are used as a fallback.
-   *
-   * @param null|string[] $exclude List of tables to exclude from diagram.
-   */
-  public function generatePuml(?string $connectionName = null, ?string $size = null, ?string $theme = null, ?array $exclude = null): string
-  {
-    // Fallback values from doctrine_diagram.yaml
-    $connectionName ??= $this->connection;
-    $size           ??= $this->size;
-    $theme          ??= $this->theme;
-    $exclude        ??= $this->exclude;
-
-    // Generate puml diagram
-    $connection = $this->doctrine->getConnection($connectionName);
-    ($connection instanceof Connection) or throw new RuntimeException('Cannot get required Connection');
-    $dbDraw = new DbDraw($connection);
-
-    return $dbDraw->generatePuml($size, $theme, $exclude);
   }
 
   public function convert(string $puml, ?string $format, ?string $converter, ?string $server, ?string $jar): string
@@ -71,13 +32,13 @@ class DoctrineDiagram
     if ($format === Format::PUML) {
       return $puml;
     }
-    $this->toolbox->isValidFormat($format) or throw new RuntimeException("Invalid format {$format}.");
+    $this->toolbox->isValidFormat($format) or throw new \RuntimeException("Invalid format {$format}.");
 
     return match ($converter) {
       Converter::JAR    => $this->convertWithJar($puml, $format, $jar),
       Converter::SERVER => $this->convertWithServer($puml, $format, $server),
       Converter::AUTO   => $this->convertAuto($puml, $format, $server, $jar),
-      default           => throw new RuntimeException('Invalid converter')
+      default           => throw new \RuntimeException('Invalid converter')
     };
   }
 

--- a/src/Service/ErDiagram.php
+++ b/src/Service/ErDiagram.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Jawira\DoctrineDiagramBundle\Service;
+
+
+use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ConnectionRegistry;
+use Jawira\DbDraw\DbDraw;
+use RuntimeException;
+
+class ErDiagram
+{
+  public function __construct(
+    private ConnectionRegistry $doctrine,
+    private string             $size,
+    private string             $theme,
+    private ?string            $connection,
+    /** @var string[] */
+    private array              $exclude,
+  ) {
+  }
+
+
+  /**
+   * Generate a Puml diagram using a Doctrine connection.
+   *
+   * The arguments of this method come from the console. If no values are provided, then the values from the config
+   * file are used as a fallback.
+   *
+   * @param null|string[] $exclude List of tables to exclude from diagram.
+   */
+  public function generatePuml(?string $connectionName = null, ?string $size = null, ?string $theme = null, ?array $exclude = null): string
+  {
+    // Fallback values from doctrine_diagram.yaml
+    $connectionName ??= $this->connection;
+    $size           ??= $this->size;
+    $theme          ??= $this->theme;
+    $exclude        ??= $this->exclude;
+
+    // Generate puml diagram
+    $connection = $this->doctrine->getConnection($connectionName);
+    ($connection instanceof Connection) or throw new RuntimeException('Cannot get required Connection');
+    $dbDraw = new DbDraw($connection);
+
+    return $dbDraw->generatePuml($size, $theme, $exclude);
+  }
+}


### PR DESCRIPTION
Refactored the architecture to separate diagram generation and conversion logic into `ErDiagram` and `ConversionService`. Replaced "doctrine:diagram" command with "doctrine:diagram:er" for creating Entity-Relationship diagrams.