### PR TITLE
feat: Create command to create a Class diagram

### DIFF
--- a/src/Command/ClassCommand.php
+++ b/src/Command/ClassCommand.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+
+namespace Jawira\DoctrineDiagramBundle\Command;
+
+use Jawira\DoctrineDiagramBundle\Constants\Config;
+use Jawira\DoctrineDiagramBundle\Constants\Info;
+use Jawira\DoctrineDiagramBundle\Service\ClassDiagram;
+use Jawira\DoctrineDiagramBundle\Service\ConversionService;
+use Jawira\DoctrineDiagramBundle\Service\DumpService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use function explode;
+use function is_string;
+
+
+/**
+ * @author  Jawira Portugal
+ */
+#[AsCommand('doctrine:diagram:class', 'Create a Class diagram.')]
+class ClassCommand extends Command
+{
+  public function __construct(
+    private readonly ClassDiagram      $classDiagram,
+    private readonly ConversionService $conversionService,
+    private readonly DumpService       $dumpService,
+  ) {
+    parent::__construct();
+  }
+
+  protected function configure(): void
+  {
+    $this
+      ->addOption(Config::FILENAME, null, InputOption::VALUE_REQUIRED, Info::FILE_NAME)
+      ->addOption(Config::FORMAT, null, InputOption::VALUE_REQUIRED, Info::FORMAT)
+      ->addOption(Config::SIZE, null, InputOption::VALUE_REQUIRED, Info::SIZE)
+      ->addOption(Config::CONVERTER, null, InputOption::VALUE_REQUIRED, Info::CONVERTER)
+      ->addOption(Config::SERVER, null, InputOption::VALUE_REQUIRED, Info::SERVER)
+      ->addOption(Config::JAR, null, InputOption::VALUE_REQUIRED, Info::JAR)
+      ->addOption(Config::EM, null, InputOption::VALUE_REQUIRED, Info::EM)
+      ->addOption(Config::THEME, null, InputOption::VALUE_REQUIRED, Info::THEME)
+      ->addOption(Config::EXCLUDE, null, InputOption::VALUE_REQUIRED, Info::EXCLUDE);
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output): int
+  {
+    $errorStyle = (new SymfonyStyle($input, $output))->getErrorStyle();
+    $errorStyle->text('<info>Doctrine Diagram Bundle</info> by <info>Jawira Portugal</info>');
+
+    $emName    = $this->stringOrNullOption($input, Config::EM);
+    $size      = $this->stringOrNullOption($input, Config::SIZE);
+    $format    = $this->stringOrNullOption($input, Config::FORMAT);
+    $server    = $this->stringOrNullOption($input, Config::SERVER);
+    $converter = $this->stringOrNullOption($input, Config::CONVERTER);
+    $jar       = $this->stringOrNullOption($input, Config::JAR);
+    $filename  = $this->stringOrNullOption($input, Config::FILENAME);
+    $theme     = $this->stringOrNullOption($input, Config::THEME);
+    $exclude   = $this->stringOrNullOption($input, Config::EXCLUDE);
+
+    $excludeArray = is_string($exclude) ? explode(',', $exclude) : null;
+
+    $puml     = $this->classDiagram->generatePuml($emName, $size, $theme, $excludeArray);
+    $content  = $this->conversionService->convert($puml, $format, $converter, $server, $jar);
+    $fullName = $this->dumpService->dumpClassDiagram($content, $filename, $format);
+
+    $errorStyle->success("Diagram: $fullName");
+
+    return Command::SUCCESS;
+  }
+
+  /**
+   * Custom function to extract console options and make PHPStan happy!
+   */
+  private function stringOrNullOption(InputInterface $input, string $optionName): ?string
+  {
+    $value = $input->getOption($optionName);
+
+    return is_string($value) ? $value : null;
+  }
+}

--- a/src/Command/ErCommand.php
+++ b/src/Command/ErCommand.php
@@ -6,6 +6,7 @@ use Jawira\DoctrineDiagramBundle\Constants\Config;
 use Jawira\DoctrineDiagramBundle\Constants\Info;
 use Jawira\DoctrineDiagramBundle\Constants\Size;
 use Jawira\DoctrineDiagramBundle\Service\ConversionService;
+use Jawira\DoctrineDiagramBundle\Service\DumpService;
 use Jawira\DoctrineDiagramBundle\Service\ErDiagram;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -13,17 +14,20 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use function explode;
+use function is_string;
 
 
 /**
  * @author  Jawira Portugal
  */
 #[AsCommand('doctrine:diagram:er', 'Create an Entity-Relationship diagram.')]
-class ErDiagramCommand extends Command
+class ErCommand extends Command
 {
   public function __construct(
-    private ErDiagram         $erDiagram,
-    private ConversionService $conversionService,
+    private readonly ErDiagram         $erDiagram,
+    private readonly ConversionService $conversionService,
+    private readonly DumpService       $dumpService,
   ) {
     parent::__construct();
   }
@@ -32,7 +36,7 @@ class ErDiagramCommand extends Command
   {
     $this
       ->setHelp(<<<'HELP'
-        Create a database diagram using a Doctrine ORM connection.
+        Create an Entity-Relationship diagram using a Doctrine ORM connection.
 
         <comment>THEMES</comment>
         Well-known themes: <info>amiga</info>, <info>blueprint</info>, <info>cerulean</info>, <info>crt-amber</info>, <info>crt-green</info>, <info>cyborg</info>, <info>lightgray</info>, <info>plain</info>, <info>silver</info>, <info>vibrant</info>.
@@ -75,7 +79,7 @@ class ErDiagramCommand extends Command
 
     $puml     = $this->erDiagram->generatePuml($connectionName, $size, $theme, $excludeArray);
     $content  = $this->conversionService->convert($puml, $format, $converter, $server, $jar);
-    $fullName = $this->conversionService->dumpDiagram($content, $filename, $format);
+    $fullName = $this->dumpService->dumpErDiagram($content, $filename, $format);
 
     $errorStyle->success("Diagram: $fullName");
 

--- a/src/Constants/Info.php
+++ b/src/Constants/Info.php
@@ -4,6 +4,8 @@ namespace Jawira\DoctrineDiagramBundle\Constants;
 
 /**
  * All descriptions for configuration flags and config files.
+ *
+ * @internal
  */
 class Info
 {
@@ -14,6 +16,7 @@ class Info
   public const SERVER = 'PlantUML server URL, used to convert puml diagrams to svg or png.';
   public const JAR = 'Path to plantuml.jar, used to convert puml diagrams to svg or png.';
   public const CONNECTION = 'Doctrine connection to use.';
+  public const EM = 'Entity Manager to use.';
   public const THEME = 'Change diagram colors and style.';
   public const EXCLUDE = 'Comma separated list of tables to exclude from diagram.';
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,7 +19,7 @@ class Configuration implements ConfigurationInterface
 {
   public function getConfigTreeBuilder(): TreeBuilder
   {
-    $buildTree = new TreeBuilder('doctrine_diagram');
+    $buildTree = new TreeBuilder(Config::ROOT);
     $rootNode  = $buildTree->getRootNode();
     ($rootNode instanceof ParentNodeDefinitionInterface) or throw new \RuntimeException('Invalid root node when configuring bundle.');
 
@@ -45,10 +45,6 @@ class Configuration implements ConfigurationInterface
       ->enumNode(Config::SIZE)
       ->values(Size::allSizes())
       ->defaultValue(Fallback::SIZE)
-      ->end()
-      ->enumNode(Config::FORMAT)
-      ->values(Format::allFormats())
-      ->defaultValue(Fallback::FORMAT)
       ->end()
       ->scalarNode(Config::THEME)
       ->defaultValue(Fallback::THEME)
@@ -78,10 +74,6 @@ class Configuration implements ConfigurationInterface
       ->values(Size::allSizes())
       ->defaultValue(Fallback::SIZE)
       ->end()
-      ->enumNode(Config::FORMAT)
-      ->values(Format::allFormats())
-      ->defaultValue(Fallback::FORMAT)
-      ->end()
       ->scalarNode(Config::THEME)
       ->defaultValue(Fallback::THEME)
       ->end()
@@ -104,6 +96,10 @@ class Configuration implements ConfigurationInterface
 
     $node->addDefaultsIfNotSet()
       ->children()
+      ->enumNode(Config::FORMAT)
+      ->values(Format::allFormats())
+      ->defaultValue(Fallback::FORMAT)
+      ->end()
       ->enumNode(Config::CONVERTER)
       ->values(Converter::allConverter())
       ->defaultValue(Fallback::CONVERTER)

--- a/src/DependencyInjection/DoctrineDiagramExtension.php
+++ b/src/DependencyInjection/DoctrineDiagramExtension.php
@@ -19,24 +19,22 @@ class DoctrineDiagramExtension extends Extension
 
     $c = Toolbox::concat(...);
     // er
-    $container->setParameter($c(C::ROOT, C::ER, C::FILENAME), $config[C::ER][C::FILENAME]);
     $container->setParameter($c(C::ROOT, C::ER, C::SIZE), $config[C::ER][C::SIZE]);
-    $container->setParameter($c(C::ROOT, C::ER, C::FORMAT), $config[C::ER][C::FORMAT]);
+    $container->setParameter($c(C::ROOT, C::ER, C::FILENAME), $config[C::ER][C::FILENAME]);
     $container->setParameter($c(C::ROOT, C::ER, C::THEME), $config[C::ER][C::THEME]);
     $container->setParameter($c(C::ROOT, C::ER, C::CONNECTION), $config[C::ER][C::CONNECTION]);
     $container->setParameter($c(C::ROOT, C::ER, C::EXCLUDE), $config[C::ER][C::EXCLUDE]);
     // class
-    $container->setParameter($c(C::ROOT, C::CLASSN, C::FILENAME), $config[C::CLASSN][C::FILENAME]);
     $container->setParameter($c(C::ROOT, C::CLASSN, C::SIZE), $config[C::CLASSN][C::SIZE]);
-    $container->setParameter($c(C::ROOT, C::CLASSN, C::FORMAT), $config[C::CLASSN][C::FORMAT]);
+    $container->setParameter($c(C::ROOT, C::CLASSN, C::FILENAME), $config[C::CLASSN][C::FILENAME]);
     $container->setParameter($c(C::ROOT, C::CLASSN, C::THEME), $config[C::CLASSN][C::THEME]);
     $container->setParameter($c(C::ROOT, C::CLASSN, C::EM), $config[C::CLASSN][C::EM]);
     $container->setParameter($c(C::ROOT, C::CLASSN, C::EXCLUDE), $config[C::CLASSN][C::EXCLUDE]);
     // convert
+    $container->setParameter($c(C::ROOT, C::CONVERT, C::FORMAT), $config[C::CONVERT][C::FORMAT]);
     $container->setParameter($c(C::ROOT, C::CONVERT, C::CONVERTER), $config[C::CONVERT][C::CONVERTER]);
     $container->setParameter($c(C::ROOT, C::CONVERT, C::JAR), $config[C::CONVERT][C::JAR]);
     $container->setParameter($c(C::ROOT, C::CONVERT, C::SERVER), $config[C::CONVERT][C::SERVER]);
-
 
     $loader = new PhpFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
     $loader->load('services.php');

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -2,9 +2,12 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Jawira\DoctrineDiagramBundle\Command\ErDiagramCommand;
+use Jawira\DoctrineDiagramBundle\Command\ClassCommand;
+use Jawira\DoctrineDiagramBundle\Command\ErCommand;
 use Jawira\DoctrineDiagramBundle\Constants\Config as C;
+use Jawira\DoctrineDiagramBundle\Service\ClassDiagram;
 use Jawira\DoctrineDiagramBundle\Service\ConversionService;
+use Jawira\DoctrineDiagramBundle\Service\DumpService;
 use Jawira\DoctrineDiagramBundle\Service\ErDiagram;
 use Jawira\DoctrineDiagramBundle\Service\Toolbox;
 use Jawira\PlantUmlToImage\PlantUml;
@@ -25,21 +28,44 @@ return function (ContainerConfigurator $container): void {
     ->arg('$connection', param($c(C::ROOT, C::ER, C::CONNECTION)))
     ->arg('$exclude', param($c(C::ROOT, C::ER, C::EXCLUDE)));
 
+  $services->set('jawira.doctrine_diagram.class_diagram', ClassDiagram::class)
+    // services
+    ->arg('$doctrine', service('doctrine'))
+    // parameters
+    ->arg('$size', param($c(C::ROOT, C::CLASSN, C::SIZE)))
+    ->arg('$theme', param($c(C::ROOT, C::CLASSN, C::THEME)))
+    ->arg('$em', param($c(C::ROOT, C::CLASSN, C::EM)))
+    ->arg('$exclude', param($c(C::ROOT, C::CLASSN, C::EXCLUDE)));
+
   $services->set('jawira.doctrine_diagram.conversion_service', ConversionService::class)
     // services
     ->arg('$pumlToImage', service('.jawira.doctrine_diagram.plantuml_to_image'))
     ->arg('$toolbox', service('.jawira.doctrine_diagram.toolbox'))
     // parameters
-    ->arg('$filename', param($c(C::ROOT, C::ER, C::FILENAME)))
-    ->arg('$format', param($c(C::ROOT, C::ER, C::FORMAT)))
+    ->arg('$format', param($c(C::ROOT, C::CONVERT, C::FORMAT)))
     ->arg('$converter', param($c(C::ROOT, C::CONVERT, C::CONVERTER)))
     ->arg('$jar', param($c(C::ROOT, C::CONVERT, C::JAR)))
     ->arg('$server', param($c(C::ROOT, C::CONVERT, C::SERVER)));
 
+  $services->set('jawira.doctrine_diagram.dump_service', DumpService::class)
+    // services
+    ->arg('$toolbox', service('.jawira.doctrine_diagram.toolbox'))
+    // parameters
+    ->arg('$erFilename', param($c(C::ROOT, C::ER, C::FILENAME)))
+    ->arg('$classFilename', param($c(C::ROOT, C::CLASSN, C::FILENAME)))
+    ->arg('$format', param($c(C::ROOT, C::CONVERT, C::FORMAT)));
 
-  $services->set('jawira.doctrine_diagram.command', ErDiagramCommand::class)
+  $services->set('jawira.doctrine_diagram.er_command', ErCommand::class)
     ->arg('$erDiagram', service('jawira.doctrine_diagram.er_diagram'))
     ->arg('$conversionService', service('jawira.doctrine_diagram.conversion_service'))
+    ->arg('$dumpService', service('jawira.doctrine_diagram.dump_service'))
+    ->tag('console.command')
+    ->private();
+
+  $services->set('jawira.doctrine_diagram.class_command', ClassCommand::class)
+    ->arg('$classDiagram', service('jawira.doctrine_diagram.class_diagram'))
+    ->arg('$conversionService', service('jawira.doctrine_diagram.conversion_service'))
+    ->arg('$dumpService', service('jawira.doctrine_diagram.dump_service'))
     ->tag('console.command')
     ->private();
 };

--- a/src/Service/ClassDiagram.php
+++ b/src/Service/ClassDiagram.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Jawira\DoctrineDiagramBundle\Service;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use Jawira\EntityDraw\EntityDraw;
+
+class ClassDiagram
+{
+  public function __construct(
+    private readonly ManagerRegistry $doctrine,
+    private readonly string          $size,
+    private readonly string          $theme,
+    private readonly ?string         $em,
+    /** @var string[] */
+    private readonly array           $exclude,
+  ) {
+  }
+
+  /**
+   * @param null|string[] $exclude List of classes to exclude from the class diagram.
+   */
+  public function generatePuml(?string $emName, ?string $size, ?string $theme, ?array $exclude): string
+  {
+    // Fallback values from doctrine_diagram.yaml
+    $emName  ??= $this->em;
+    $size    ??= $this->size;
+    $theme   ??= $this->theme;
+    $exclude ??= $this->exclude;
+
+    // Generate puml diagram
+    $entityManager = $this->doctrine->getManager($emName);
+    ($entityManager instanceof EntityManagerInterface) or throw new \RuntimeException('Cannot get required Entity Manager');
+    $entityDraw = new EntityDraw($entityManager);
+
+    return $entityDraw->generatePuml($size, $theme, $exclude);
+  }
+}

--- a/src/Service/ConversionService.php
+++ b/src/Service/ConversionService.php
@@ -7,17 +7,18 @@ use Jawira\DoctrineDiagramBundle\Constants\Format;
 use Jawira\PlantUmlClient\Client;
 use Jawira\PlantUmlToImage\PlantUml;
 
+/**
+ * Convert PUML diagram to another format when required.
+ */
 class ConversionService
 {
   public function __construct(
-
-    private PlantUml $pumlToImage,
-    private Toolbox  $toolbox,
-    private string   $filename,
-    private string   $format,
-    private ?string  $jar,
-    private string   $server,
-    private string   $converter,
+    private readonly PlantUml $pumlToImage,
+    private readonly Toolbox  $toolbox,
+    private readonly string   $format,
+    private readonly ?string  $jar,
+    private readonly string   $server,
+    private readonly string   $converter,
   ) {
   }
 
@@ -80,26 +81,5 @@ class ConversionService
   private function convertWithServer(string $puml, string $format, string $server): string
   {
     return (new Client($server))->generateImage($puml, $format);
-  }
-
-  /**
-   * Dump image into a file.
-   *
-   * @param string      $content  The diagram content to be dumped.
-   * @param string|null $filename Target file name. This can be a path, {@see Filesystem} is able to handle it.
-   * @param string|null $format   Target file extension.
-   */
-  public function dumpDiagram(string $content, ?string $filename, ?string $format): string
-  {
-    // Fallback values from doctrine_diagram.yaml
-    $filename ??= $this->filename;
-    $format   ??= $this->format;
-
-    if (!$this->toolbox->isWrapper($filename)) {
-      $filename = $this->toolbox->appendExtension($filename, $format);
-    }
-    file_put_contents($filename, $content);
-
-    return $filename;
   }
 }

--- a/src/Service/DumpService.php
+++ b/src/Service/DumpService.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Jawira\DoctrineDiagramBundle\Service;
+
+/**
+ * Save the diagram into a file.
+ */
+class DumpService
+{
+  public function __construct(
+    private readonly Toolbox $toolbox,
+    private readonly string  $erFilename,
+    private readonly string  $classFilename,
+    private readonly string  $format,
+  ) {
+  }
+
+  /**
+   * @param string      $content  The content to write into the file.
+   * @param string|null $filename Target file name. This can be a path, {@see Filesystem} is able to handle it.
+   * @param string|null $format   Target file extension.
+   *
+   * @return string The filename with the current extension.
+   */
+  public function dumpErDiagram(string $content, ?string $filename, ?string $format): string
+  {
+    // Fallback values from doctrine_diagram.yaml
+    $filename ??= $this->erFilename;
+    return $this->dumpDiagram($content, $filename, $format);
+  }
+
+  public function dumpClassDiagram(string $content, ?string $filename, ?string $format): string
+  {
+    // Fallback values from doctrine_diagram.yaml
+    $filename ??= $this->classFilename;
+    return $this->dumpDiagram($content, $filename, $format);
+  }
+
+  /**
+   * Dump the image into a file.
+   *
+   * @param string      $content  The content to write into the file.
+   * @param string      $filename Target file name. This can be a path, {@see Filesystem} is able to handle it.
+   * @param string|null $format   Target file extension.
+   */
+  private function dumpDiagram(string $content, string $filename, ?string $format): string
+  {
+    // Fallback values from doctrine_diagram.yaml
+    $format ??= $this->format;
+
+    if (!$this->toolbox->isWrapper($filename)) {
+      $filename = $this->toolbox->appendExtension($filename, $format);
+    }
+    file_put_contents($filename, $content);
+
+    return $filename;
+  }
+}

--- a/src/Service/ErDiagram.php
+++ b/src/Service/ErDiagram.php
@@ -4,19 +4,19 @@ namespace Jawira\DoctrineDiagramBundle\Service;
 
 
 use Doctrine\DBAL\Connection;
-use Doctrine\Persistence\ConnectionRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Jawira\DbDraw\DbDraw;
 use RuntimeException;
 
 class ErDiagram
 {
   public function __construct(
-    private ConnectionRegistry $doctrine,
-    private string             $size,
-    private string             $theme,
-    private ?string            $connection,
+    private readonly ManagerRegistry $doctrine,
+    private readonly string          $size,
+    private readonly string          $theme,
+    private readonly ?string         $connection,
     /** @var string[] */
-    private array              $exclude,
+    private readonly array           $exclude,
   ) {
   }
 
@@ -27,9 +27,9 @@ class ErDiagram
    * The arguments of this method come from the console. If no values are provided, then the values from the config
    * file are used as a fallback.
    *
-   * @param null|string[] $exclude List of tables to exclude from diagram.
+   * @param null|string[] $exclude List of tables to exclude from the diagram.
    */
-  public function generatePuml(?string $connectionName = null, ?string $size = null, ?string $theme = null, ?array $exclude = null): string
+  public function generatePuml(?string $connectionName, ?string $size, ?string $theme, ?array $exclude): string
   {
     // Fallback values from doctrine_diagram.yaml
     $connectionName ??= $this->connection;
@@ -39,7 +39,7 @@ class ErDiagram
 
     // Generate puml diagram
     $connection = $this->doctrine->getConnection($connectionName);
-    ($connection instanceof Connection) or throw new RuntimeException('Cannot get required Connection');
+    ($connection instanceof Connection) or throw new RuntimeException('Cannot get required required Connection');
     $dbDraw = new DbDraw($connection);
 
     return $dbDraw->generatePuml($size, $theme, $exclude);


### PR DESCRIPTION
Introduce a `DumpService` to handle file dumping for diagrams, centralizing logic previously in `ConversionService`. Add a new `ClassCommand` and related `ClassDiagram` service to support generating Class diagrams. Update parameters, dependencies, and services for better modularity and reuse across `Entity-Relationship` and `Class` diagram features.