### PR TITLE
require multiple --exclude flags instead of comma-separated values

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,21 @@
+# Upgrade from 1.x to 2.0
+
+This document describes the changes required to migrate from `v1` to `v2`.
+
+## Breaking changes
+
+### The `--exclude` option
+
+Previously, the `--exclude` option was a comma separated list of values.
+
+```console
+--exclude=user,customer,invoice
+```
+
+In v2 you have to split this value into multiple `--exclude` calls:
+
+```console
+--exclude=user --exclude=customer --exclude=invoice
+```
+
+This change applies to `doctrine:diagram:er` and `doctrine:diagram:class` command.

--- a/src/Command/ClassCommand.php
+++ b/src/Command/ClassCommand.php
@@ -7,14 +7,13 @@ use Jawira\DoctrineDiagramBundle\Constants\Info;
 use Jawira\DoctrineDiagramBundle\Service\ClassDiagram;
 use Jawira\DoctrineDiagramBundle\Service\ConversionService;
 use Jawira\DoctrineDiagramBundle\Service\DumpService;
+use Jawira\DoctrineDiagramBundle\Service\Toolbox;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use function explode;
-use function is_string;
 
 
 /**
@@ -27,6 +26,7 @@ class ClassCommand extends Command
     private readonly ClassDiagram      $classDiagram,
     private readonly ConversionService $conversionService,
     private readonly DumpService       $dumpService,
+    private readonly Toolbox           $toolbox,
   ) {
     parent::__construct();
   }
@@ -34,6 +34,7 @@ class ClassCommand extends Command
   protected function configure(): void
   {
     $this
+      ->setHelp('Create a Class diagram using a Doctrine ORM Entity Manager.' . PHP_EOL . PHP_EOL . Info::HELP)
       ->addOption(Config::FILENAME, null, InputOption::VALUE_REQUIRED, Info::FILE_NAME)
       ->addOption(Config::FORMAT, null, InputOption::VALUE_REQUIRED, Info::FORMAT)
       ->addOption(Config::SIZE, null, InputOption::VALUE_REQUIRED, Info::SIZE)
@@ -42,42 +43,30 @@ class ClassCommand extends Command
       ->addOption(Config::JAR, null, InputOption::VALUE_REQUIRED, Info::JAR)
       ->addOption(Config::EM, null, InputOption::VALUE_REQUIRED, Info::EM)
       ->addOption(Config::THEME, null, InputOption::VALUE_REQUIRED, Info::THEME)
-      ->addOption(Config::EXCLUDE, null, InputOption::VALUE_REQUIRED, Info::EXCLUDE);
+      ->addOption(Config::EXCLUDE, null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, Info::EXCLUDE_CLASS);
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int
   {
     $errorStyle = (new SymfonyStyle($input, $output))->getErrorStyle();
-    $errorStyle->text('<info>Doctrine Diagram Bundle</info> by <info>Jawira Portugal</info>');
+    $errorStyle->text(Info::CREDITS);
 
-    $emName    = $this->stringOrNullOption($input, Config::EM);
-    $size      = $this->stringOrNullOption($input, Config::SIZE);
-    $format    = $this->stringOrNullOption($input, Config::FORMAT);
-    $server    = $this->stringOrNullOption($input, Config::SERVER);
-    $converter = $this->stringOrNullOption($input, Config::CONVERTER);
-    $jar       = $this->stringOrNullOption($input, Config::JAR);
-    $filename  = $this->stringOrNullOption($input, Config::FILENAME);
-    $theme     = $this->stringOrNullOption($input, Config::THEME);
-    $exclude   = $this->stringOrNullOption($input, Config::EXCLUDE);
+    $emName    = $this->toolbox->readStringOrNullOption($input, Config::EM);
+    $size      = $this->toolbox->readStringOrNullOption($input, Config::SIZE);
+    $format    = $this->toolbox->readStringOrNullOption($input, Config::FORMAT);
+    $server    = $this->toolbox->readStringOrNullOption($input, Config::SERVER);
+    $converter = $this->toolbox->readStringOrNullOption($input, Config::CONVERTER);
+    $jar       = $this->toolbox->readStringOrNullOption($input, Config::JAR);
+    $filename  = $this->toolbox->readStringOrNullOption($input, Config::FILENAME);
+    $theme     = $this->toolbox->readStringOrNullOption($input, Config::THEME);
+    $exclude   = $this->toolbox->readArrayOrNullOption($input, Config::EXCLUDE);
 
-    $excludeArray = is_string($exclude) ? explode(',', $exclude) : null;
-
-    $puml     = $this->classDiagram->generatePuml($emName, $size, $theme, $excludeArray);
+    $puml     = $this->classDiagram->generatePuml($emName, $size, $theme, $exclude);
     $content  = $this->conversionService->convert($puml, $format, $converter, $server, $jar);
     $fullName = $this->dumpService->dumpClassDiagram($content, $filename, $format);
 
-    $errorStyle->success("Diagram: $fullName");
+    $errorStyle->success("Class diagram: $fullName");
 
     return Command::SUCCESS;
-  }
-
-  /**
-   * Custom function to extract console options and make PHPStan happy!
-   */
-  private function stringOrNullOption(InputInterface $input, string $optionName): ?string
-  {
-    $value = $input->getOption($optionName);
-
-    return is_string($value) ? $value : null;
   }
 }

--- a/src/Command/ErCommand.php
+++ b/src/Command/ErCommand.php
@@ -4,19 +4,16 @@ namespace Jawira\DoctrineDiagramBundle\Command;
 
 use Jawira\DoctrineDiagramBundle\Constants\Config;
 use Jawira\DoctrineDiagramBundle\Constants\Info;
-use Jawira\DoctrineDiagramBundle\Constants\Size;
 use Jawira\DoctrineDiagramBundle\Service\ConversionService;
 use Jawira\DoctrineDiagramBundle\Service\DumpService;
 use Jawira\DoctrineDiagramBundle\Service\ErDiagram;
+use Jawira\DoctrineDiagramBundle\Service\Toolbox;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use function explode;
-use function is_string;
-
 
 /**
  * @author  Jawira Portugal
@@ -28,6 +25,7 @@ class ErCommand extends Command
     private readonly ErDiagram         $erDiagram,
     private readonly ConversionService $conversionService,
     private readonly DumpService       $dumpService,
+    private readonly Toolbox           $toolbox,
   ) {
     parent::__construct();
   }
@@ -35,20 +33,7 @@ class ErCommand extends Command
   protected function configure(): void
   {
     $this
-      ->setHelp(<<<'HELP'
-        Create an Entity-Relationship diagram using a Doctrine ORM connection.
-
-        <comment>THEMES</comment>
-        Well-known themes: <info>amiga</info>, <info>blueprint</info>, <info>cerulean</info>, <info>crt-amber</info>, <info>crt-green</info>, <info>cyborg</info>, <info>lightgray</info>, <info>plain</info>, <info>silver</info>, <info>vibrant</info>.
-        Please note that the availability of themes may vary depending on the specific version of PlantUML being used to render the diagrams.
-
-        <comment>FORMATS</comment>
-        Use PlantUML format <info>puml</info> if you are experiencing problems when creating a diagram.
-        Unlike <info>png</info> and <info>svg</info> formats, <info>puml</info> doesn't require an internet connection.
-        HELP
-      )
-      ->addUsage(sprintf('--%s=project.png --%s=png', Config::FILENAME, Config::FORMAT))
-      ->addUsage(sprintf('--%s=%s', Config::SIZE, Size::MINI))
+      ->setHelp('Create an Entity-Relationship diagram using a Doctrine ORM connection.' . PHP_EOL . PHP_EOL . Info::HELP)
       ->addOption(Config::FILENAME, null, InputOption::VALUE_REQUIRED, Info::FILE_NAME)
       ->addOption(Config::FORMAT, null, InputOption::VALUE_REQUIRED, Info::FORMAT)
       ->addOption(Config::SIZE, null, InputOption::VALUE_REQUIRED, Info::SIZE)
@@ -57,42 +42,30 @@ class ErCommand extends Command
       ->addOption(Config::JAR, null, InputOption::VALUE_REQUIRED, Info::JAR)
       ->addOption(Config::CONNECTION, null, InputOption::VALUE_REQUIRED, Info::CONNECTION)
       ->addOption(Config::THEME, null, InputOption::VALUE_REQUIRED, Info::THEME)
-      ->addOption(Config::EXCLUDE, null, InputOption::VALUE_REQUIRED, Info::EXCLUDE);
+      ->addOption(Config::EXCLUDE, null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, Info::EXCLUDE_ER);
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int
   {
     $errorStyle = (new SymfonyStyle($input, $output))->getErrorStyle();
-    $errorStyle->text('<info>Doctrine Diagram Bundle</info> by <info>Jawira Portugal</info>');
+    $errorStyle->text(Info::CREDITS);
 
-    $connectionName = $this->stringOrNullOption($input, Config::CONNECTION);
-    $size           = $this->stringOrNullOption($input, Config::SIZE);
-    $format         = $this->stringOrNullOption($input, Config::FORMAT);
-    $server         = $this->stringOrNullOption($input, Config::SERVER);
-    $converter      = $this->stringOrNullOption($input, Config::CONVERTER);
-    $jar            = $this->stringOrNullOption($input, Config::JAR);
-    $filename       = $this->stringOrNullOption($input, Config::FILENAME);
-    $theme          = $this->stringOrNullOption($input, Config::THEME);
-    $exclude        = $this->stringOrNullOption($input, Config::EXCLUDE);
+    $connectionName = $this->toolbox->readStringOrNullOption($input, Config::CONNECTION);
+    $size           = $this->toolbox->readStringOrNullOption($input, Config::SIZE);
+    $format         = $this->toolbox->readStringOrNullOption($input, Config::FORMAT);
+    $server         = $this->toolbox->readStringOrNullOption($input, Config::SERVER);
+    $converter      = $this->toolbox->readStringOrNullOption($input, Config::CONVERTER);
+    $jar            = $this->toolbox->readStringOrNullOption($input, Config::JAR);
+    $filename       = $this->toolbox->readStringOrNullOption($input, Config::FILENAME);
+    $theme          = $this->toolbox->readStringOrNullOption($input, Config::THEME);
+    $exclude        = $this->toolbox->readArrayOrNullOption($input, Config::EXCLUDE);
 
-    $excludeArray = is_string($exclude) ? explode(',', $exclude) : null;
-
-    $puml     = $this->erDiagram->generatePuml($connectionName, $size, $theme, $excludeArray);
+    $puml     = $this->erDiagram->generatePuml($connectionName, $size, $theme, $exclude);
     $content  = $this->conversionService->convert($puml, $format, $converter, $server, $jar);
     $fullName = $this->dumpService->dumpErDiagram($content, $filename, $format);
 
-    $errorStyle->success("Diagram: $fullName");
+    $errorStyle->success("Entity-Relationship diagram: $fullName");
 
     return Command::SUCCESS;
-  }
-
-  /**
-   * Custom function to extract console options and make PHPStan happy!
-   */
-  private function stringOrNullOption(InputInterface $input, string $optionName): ?string
-  {
-    $value = $input->getOption($optionName);
-
-    return is_string($value) ? $value : null;
   }
 }

--- a/src/Constants/Info.php
+++ b/src/Constants/Info.php
@@ -17,6 +17,18 @@ class Info
   public const JAR = 'Path to plantuml.jar, used to convert puml diagrams to svg or png.';
   public const CONNECTION = 'Doctrine connection to use.';
   public const EM = 'Entity Manager to use.';
-  public const THEME = 'Change diagram colors and style.';
-  public const EXCLUDE = 'Comma separated list of tables to exclude from diagram.';
+  public const THEME = 'Theme name, this will change colors and style.';
+  public const EXCLUDE_ER = 'Name of the table to exclude from the diagram.';
+  public const EXCLUDE_CLASS = 'Name of the class to exclude from the diagram.';
+  public const  HELP = <<<'HELP'
+    <comment>THEMES</comment>
+    Well-known themes: <info>amiga</info>, <info>blueprint</info>, <info>cerulean</info>, <info>crt-amber</info>, <info>crt-green</info>, <info>cyborg</info>, <info>lightgray</info>, <info>plain</info>, <info>silver</info>, <info>vibrant</info>.
+    Please note that the availability of themes may vary depending on the specific version of PlantUML being used to render the diagrams.
+    More about PlantUML themes: https://plantuml.com/es/theme
+
+    <comment>FORMATS</comment>
+    Use PlantUML format <info>puml</info> if you are experiencing problems when creating a diagram.
+    Unlike <info>png</info> and <info>svg</info> formats, <info>puml</info> doesn't require an internet connection.
+    HELP;
+  public const CREDITS = '<info>Doctrine Diagram Bundle</info> by <info>Jawira Portugal</info>';
 }

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -18,47 +18,47 @@ return function (ContainerConfigurator $container): void {
   $services->set('.jawira.doctrine_diagram.plantuml_to_image', PlantUml::class);
   $services->set('.jawira.doctrine_diagram.toolbox', Toolbox::class);
 
-  $c = Toolbox::concat(...);
   $services->set('jawira.doctrine_diagram.er_diagram', ErDiagram::class)
     // services
     ->arg('$doctrine', service('doctrine'))
     // parameters
-    ->arg('$size', param($c(C::ROOT, C::ER, C::SIZE)))
-    ->arg('$theme', param($c(C::ROOT, C::ER, C::THEME)))
-    ->arg('$connection', param($c(C::ROOT, C::ER, C::CONNECTION)))
-    ->arg('$exclude', param($c(C::ROOT, C::ER, C::EXCLUDE)));
+    ->arg('$size', param(Toolbox::concat(C::ROOT, C::ER, C::SIZE)))
+    ->arg('$theme', param(Toolbox::concat(C::ROOT, C::ER, C::THEME)))
+    ->arg('$connection', param(Toolbox::concat(C::ROOT, C::ER, C::CONNECTION)))
+    ->arg('$exclude', param(Toolbox::concat(C::ROOT, C::ER, C::EXCLUDE)));
 
   $services->set('jawira.doctrine_diagram.class_diagram', ClassDiagram::class)
     // services
     ->arg('$doctrine', service('doctrine'))
     // parameters
-    ->arg('$size', param($c(C::ROOT, C::CLASSN, C::SIZE)))
-    ->arg('$theme', param($c(C::ROOT, C::CLASSN, C::THEME)))
-    ->arg('$em', param($c(C::ROOT, C::CLASSN, C::EM)))
-    ->arg('$exclude', param($c(C::ROOT, C::CLASSN, C::EXCLUDE)));
+    ->arg('$size', param(Toolbox::concat(C::ROOT, C::CLASSN, C::SIZE)))
+    ->arg('$theme', param(Toolbox::concat(C::ROOT, C::CLASSN, C::THEME)))
+    ->arg('$em', param(Toolbox::concat(C::ROOT, C::CLASSN, C::EM)))
+    ->arg('$exclude', param(Toolbox::concat(C::ROOT, C::CLASSN, C::EXCLUDE)));
 
   $services->set('jawira.doctrine_diagram.conversion_service', ConversionService::class)
     // services
     ->arg('$pumlToImage', service('.jawira.doctrine_diagram.plantuml_to_image'))
     ->arg('$toolbox', service('.jawira.doctrine_diagram.toolbox'))
     // parameters
-    ->arg('$format', param($c(C::ROOT, C::CONVERT, C::FORMAT)))
-    ->arg('$converter', param($c(C::ROOT, C::CONVERT, C::CONVERTER)))
-    ->arg('$jar', param($c(C::ROOT, C::CONVERT, C::JAR)))
-    ->arg('$server', param($c(C::ROOT, C::CONVERT, C::SERVER)));
+    ->arg('$format', param(Toolbox::concat(C::ROOT, C::CONVERT, C::FORMAT)))
+    ->arg('$converter', param(Toolbox::concat(C::ROOT, C::CONVERT, C::CONVERTER)))
+    ->arg('$jar', param(Toolbox::concat(C::ROOT, C::CONVERT, C::JAR)))
+    ->arg('$server', param(Toolbox::concat(C::ROOT, C::CONVERT, C::SERVER)));
 
   $services->set('jawira.doctrine_diagram.dump_service', DumpService::class)
     // services
     ->arg('$toolbox', service('.jawira.doctrine_diagram.toolbox'))
     // parameters
-    ->arg('$erFilename', param($c(C::ROOT, C::ER, C::FILENAME)))
-    ->arg('$classFilename', param($c(C::ROOT, C::CLASSN, C::FILENAME)))
-    ->arg('$format', param($c(C::ROOT, C::CONVERT, C::FORMAT)));
+    ->arg('$erFilename', param(Toolbox::concat(C::ROOT, C::ER, C::FILENAME)))
+    ->arg('$classFilename', param(Toolbox::concat(C::ROOT, C::CLASSN, C::FILENAME)))
+    ->arg('$format', param(Toolbox::concat(C::ROOT, C::CONVERT, C::FORMAT)));
 
   $services->set('jawira.doctrine_diagram.er_command', ErCommand::class)
     ->arg('$erDiagram', service('jawira.doctrine_diagram.er_diagram'))
     ->arg('$conversionService', service('jawira.doctrine_diagram.conversion_service'))
     ->arg('$dumpService', service('jawira.doctrine_diagram.dump_service'))
+    ->arg('$toolbox', service('.jawira.doctrine_diagram.toolbox'))
     ->tag('console.command')
     ->private();
 
@@ -66,6 +66,7 @@ return function (ContainerConfigurator $container): void {
     ->arg('$classDiagram', service('jawira.doctrine_diagram.class_diagram'))
     ->arg('$conversionService', service('jawira.doctrine_diagram.conversion_service'))
     ->arg('$dumpService', service('jawira.doctrine_diagram.dump_service'))
+    ->arg('$toolbox', service('.jawira.doctrine_diagram.toolbox'))
     ->tag('console.command')
     ->private();
 };

--- a/src/Service/Toolbox.php
+++ b/src/Service/Toolbox.php
@@ -2,11 +2,16 @@
 
 namespace Jawira\DoctrineDiagramBundle\Service;
 
+use InvalidArgumentException;
 use Jawira\DoctrineDiagramBundle\Constants\Format;
 use ReflectionClass;
+use Symfony\Component\Console\Input\InputInterface;
+use UnexpectedValueException;
 use function boolval;
 use function implode;
 use function in_array;
+use function is_array;
+use function is_string;
 use function preg_match;
 use function str_ends_with;
 
@@ -51,5 +56,41 @@ class Toolbox
   static public function concat(string ...$params): string
   {
     return implode('.', $params);
+  }
+
+  /**
+   * Read options that must be string.
+   *
+   * Null must be returned when option is not set.
+   * Custom function to extract console options and make PHPStan happy!
+   */
+  public function readStringOrNullOption(InputInterface $input, string $optionName): ?string
+  {
+    $value = $input->getOption($optionName);
+
+    return is_string($value) ? $value : null;
+  }
+
+  /**
+   * Read an array of strings from Command input.
+   *
+   * Null value is important, it must be returned when option is not set.
+   * This method will make PHPStan happy.
+   *
+   * @return string[]|null
+   */
+  public function readArrayOrNullOption(InputInterface $input, string $optionName): ?array
+  {
+    $value = $input->getOption($optionName);
+    if ($value === null) {
+      return null;
+    }
+    is_array($value) or throw new InvalidArgumentException('Input value must be array');
+    foreach ($value as $item) {
+      is_string($item) or throw new UnexpectedValueException('Array element must be string');
+    }
+
+    /** @var string[] $value */
+    return $value;
   }
 }


### PR DESCRIPTION
The `--exclude` option no longer accepts comma-separated values. Users must pass multiple `--exclude` flags for `doctrine:diagram:er` and `doctrine:diagram:class` commands.